### PR TITLE
Preparar entorno con docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ Míralo en acción en [https://pepellou.github.io/ayuda-alimentos-coronavirus/](
     php php/run.php collect
 ```
 
+## Instalación local con Docker
+
+### Requisitos
+
+- docker 19+
+- docker-compose 1.25+
+
+### Comandos
+
+- Arrancar la web (sólo html):
+  ```
+  docker-compose up --build
+  ```
+- Limpiar containers, volúmenes e imágenes:
+  ```
+  docker-compose down --rmi local --volumes
+  ```
+
 ## Capturas de pantalla
 
 ![Listado filtrable](/screenshots/list.png)

--- a/README.md
+++ b/README.md
@@ -62,12 +62,28 @@ Míralo en acción en [https://pepellou.github.io/ayuda-alimentos-coronavirus/](
 
 - docker 19+
 - docker-compose 1.25+
+- Configurar `php/config.php` y `php/firebase-credentials.json` como se especifica en la sección anterior
 
 ### Comandos
 
+- Construir/descargar las imágenes necesarias:
+  ```
+  docker-compose pull
+  docker-compose build
+  ```
 - Arrancar la web (sólo html):
   ```
-  docker-compose up --build
+  docker-compose up app
+  ```
+- Ejecutar comandos del backend:
+  ```
+  docker-compose run --rm backend <COMANDO>
+  ```
+  Ejemplo:
+  ```
+  docker-compose run --rm backend db
+  docker-compose run --rm backend last
+  docker-compose run --rm backend collect
   ```
 - Limpiar containers, volúmenes e imágenes:
   ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       - .:/usr/local/apache2/htdocs
     ports:
       - 3000:80
+
+  backend:
+    build: ./php
+    volumes:
+      - ./php:/opt/app
+      - /opt/app/vendor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+
+services:
+  app:
+    image: httpd:2.4.41-alpine
+    volumes:
+      - .:/usr/local/apache2/htdocs
+    ports:
+      - 3000:80

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:7.4.3-cli-alpine3.10
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+ENV APP /opt/app
+WORKDIR $APP
+
+COPY composer.json $APP
+RUN composer install
+
+COPY . .
+ENTRYPOINT ["php", "run.php"]


### PR DESCRIPTION
Para evitar tener que instalar PHP en la maquina hemos preparado un docker-compose para que reduzca un poco la barrera de entrada a colaborar en el proyecto.

## Comandos disponibles:

- Construir/descargar las imágenes necesarias:
  ```
  docker-compose pull
  docker-compose build
  ```
- Arrancar la web (sólo html):
  ```
  docker-compose up app
  ```
- Ejecutar comandos del backend:
  ```
  docker-compose run --rm backend <COMANDO>
  ```
  Ejemplo:
  ```
  docker-compose run --rm backend db
  docker-compose run --rm backend last
  docker-compose run --rm backend collect
  ```
- Limpiar containers, volúmenes e imágenes:
  ```
  docker-compose down --rmi local --volumes
  ```
